### PR TITLE
Added method to get subtags

### DIFF
--- a/backend/cello/migrations/0004_subtag.py
+++ b/backend/cello/migrations/0004_subtag.py
@@ -15,8 +15,8 @@ class Migration(migrations.Migration):
             name='Subtag',
             fields=[
                 ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('child_id', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='child_id', to='cello.tag')),
                 ('parent_id', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='parent_id', to='cello.tag')),
+                ('child_id', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='child_id', to='cello.tag')),
             ],
         ),
     ]

--- a/backend/cello/serializers.py
+++ b/backend/cello/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Book, ExerciseInfo, Tag
+from .models import Book, ExerciseInfo, Tag, Subtag
 
 class BookSerializer(serializers.ModelSerializer):
     class Meta:
@@ -20,3 +20,11 @@ class ExerciseInfoSerializer(serializers.ModelSerializer):
     class Meta:
         model = ExerciseInfo
         fields = ('id', 'side', 'page_and_exercise', 'tenor', 'treble', 'book_id', 'book', 'tag')
+
+
+class SubtagSerializer(serializers.ModelSerializer):
+    tag = TagSerializer(source='child_id')
+
+    class Meta:
+        model = Subtag
+        fields = ('tag',)

--- a/backend/cello/urls.py
+++ b/backend/cello/urls.py
@@ -4,7 +4,7 @@ from rest_framework import routers
 from cello.views.author_view import AuthorView
 from cello.views.book_view import BookView
 from cello.views.exerciseinfo_view import ExerciseInfoView
-from cello.views.tag_view import TagView, TagByExerciseView, TagByLevelView
+from cello.views.tag_view import TagView, TagByExerciseView, TagByLevelView, SubtagView
 
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
@@ -23,4 +23,5 @@ urlpatterns = [
     path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('tag/exercise/<int:exercise_id>/', TagByExerciseView.as_view({'get': 'list'}), name='tag-by-exercise'),
     path('tag/level/<int:level_num>/',TagByLevelView.as_view({'get': 'list'}), name='tag-by-level'),
+    path('tag/subtag/<int:tag_id>', SubtagView.as_view({'get': 'list'}, name='subtag-view'))
 ]

--- a/backend/cello/views/tag_view.py
+++ b/backend/cello/views/tag_view.py
@@ -1,8 +1,8 @@
 # API endpoints here begin with /api/tag
 from rest_framework import viewsets
 from cello.pagination import StandardResultsSetPagination
-from ..serializers import TagSerializer
-from ..models import Tag, ExerciseInfo
+from ..serializers import TagSerializer, SubtagSerializer
+from ..models import Tag, ExerciseInfo, Subtag
 
 class TagView(viewsets.ModelViewSet):
     serializer_class = TagSerializer
@@ -28,4 +28,14 @@ class TagByLevelView(viewsets.ModelViewSet):
         level_num = self.kwargs['level_num']
         queryset = Tag.objects.filter(level=level_num).order_by('id')
         return queryset
-    
+
+# /api/tag/subtag/<tag_id>
+# Gets all the subtags of <tag_id>
+class SubtagView(viewsets.ModelViewSet):
+    serializer_class = SubtagSerializer
+    pagination_class = StandardResultsSetPagination
+
+    def get_queryset(self):
+        tag_id = self.kwargs['tag_id']
+        queryset = Subtag.objects.filter(parent_id=tag_id)
+        return queryset


### PR DESCRIPTION
```api/tag/subtag/<tag_id>```
Returns all subtags of tag <tag_id>.

Example: ```api/tag/subtag/2```

```
{
    "count": 2,
    "next": null,
    "previous": null,
    "results": [
        {
            "tag": {
                "id": 3,
                "level": 2,
                "tag_name": "4 in Thumb Position"
            }
        },
        {
            "tag": {
                "id": 113,
                "level": 3,
                "tag_name": "Broken Chord Exercises"
            }
        }
    ]
}
```

Use the new pgdump in database_conversion - the child and parent column were incorrectly named previously.