### PR TITLE
Fixed duplicate values returning for exercise info

### DIFF
--- a/backend/cello/views/exerciseinfo_view.py
+++ b/backend/cello/views/exerciseinfo_view.py
@@ -85,7 +85,7 @@ class ExerciseInfoView(viewsets.ModelViewSet):
             elif 'tenor' in clef:
                 queryset = queryset.filter(tenor=True)       
 
-        return queryset
+        return queryset.distinct()
 
 class ExerciseRandomView(ListAPIView):
 


### PR DESCRIPTION
Wasn't sure how to duplicate the bug. But it should be fixed regardless.

(Some exercises were returning more than once for api/exerciseinfo/)